### PR TITLE
resolves #11 yarn outdated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,10 +67,11 @@ jobs:
     steps:
       - checkout
       - *restore_yarn_cache
+      - *dependencies
 
       - run:
           name: Check dependencies
-          comamnd: yarn outdated
+          command: yarn outdated
 
   build:
     <<: *defaults


### PR DESCRIPTION
- moves CI from Travis to Circle
- moves coverage reporting from coveralls to codecov